### PR TITLE
feat: add PDF output via pdfmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ powerautodocs covers the full stack of a Dataverse/Power Platform solution:
 
 ---
 
+## How it works
+
+powerautodocs uses a layered IR (Intermediate Representation) pipeline:
+
+```
+Unpacked Solution XML/JSON
+        ↓
+    Parsers (one per component type)
+        ↓
+    IR (typed TypeScript interfaces)
+        ↓
+    Enrichment (ERD, Mermaid diagrams, optional AI summaries)
+        ↓
+    Renderers (emit format-agnostic DocNode[])
+        ↓
+    MarkdownSerializer → ADO Wiki Publisher (REST API)
+    DocxSerializer     → Word .docx file
+    PdfSerializer      → PDF file
+```
+
+Parsers only produce IR. Renderers only consume IR. Neither knows about the other — swap or add output formats without touching the parsing logic.
+
+---
+
 ## Quick Start
 
 **1. Unpack your solution**
@@ -50,27 +74,35 @@ pac solution unpack --zipfile MySolution.zip --folder ./unpacked/MySolution
 npx powerautodocs@latest
 ```
 
-Output is controlled by `output.wiki` and `output.word` in your config, or via CLI flags:
+Output is controlled by `output.wiki`, `output.word` and `output.pdf` in your config, or via CLI flags:
 
 ```bash
-npx powerautodocs@latest --wiki          # Wiki only
-npx powerautodocs@latest --word          # Word only
-npx powerautodocs@latest --wiki --word   # Both
-npx powerautodocs@latest --regenerate-ai # Force a full AI summary refresh, ignoring the cache
+npx powerautodocs@latest --wiki                 # Wiki only
+npx powerautodocs@latest --word                 # Word only
+npx powerautodocs@latest --pdf                  # PDF only
+npx powerautodocs@latest --wiki --word --pdf    # Any combination
+npx powerautodocs@latest --regenerate-ai        # Force a full AI summary refresh, ignoring the cache
 ```
 
 ---
 
 ## Output modes
 
-powerautodocs supports two output formats, configurable independently:
+powerautodocs supports three output formats, configurable independently:
 
 | Mode | Config flag | CLI flag | Output |
 | --- | --- | --- | --- |
 | ADO Wiki | `output.wiki: true` | `--wiki` | Pages published to Azure DevOps Wiki via REST API |
 | Word document | `output.word: true` | `--word` | `.docx` file written to `output/` folder |
+| PDF document | `output.pdf: true` | `--pdf` | `.pdf` file written to `output/` folder (local only — not published to ADO Wiki) |
 
-CLI flags override the config file. If no flags are passed, the config drives everything.
+CLI flags override the config file — passing any one of `--wiki` / `--word` / `--pdf` treats the
+set you pass as the explicit output selection (unlisted formats are suppressed for that run, even
+if enabled in config). If no flags are passed, the config drives everything.
+
+Like the Word document, the PDF is a single self-contained file mirroring the wiki structure.
+Mermaid diagrams (ERD, flow charts) are omitted from both Word and PDF output — they're rendered
+in the ADO Wiki only.
 
 ---
 
@@ -179,6 +211,8 @@ output:
   wiki: true
   word: true
   wordFilename: solution-documentation.docx
+  pdf: false
+  pdfFilename: solution-documentation.pdf
 
 wiki:
   organisation: MyOrg
@@ -255,30 +289,7 @@ If your config lives outside the repo root, pass its location via environment va
 
 - Node.js 18+
 - Power Platform CLI (`pac`) — for unpacking solutions
-- Azure DevOps Wiki — for wiki output (optional if using Word only)
-
----
-
-## How it works
-
-powerautodocs uses a layered IR (Intermediate Representation) pipeline:
-
-```
-Unpacked Solution XML/JSON
-        ↓
-    Parsers (one per component type)
-        ↓
-    IR (typed TypeScript interfaces)
-        ↓
-    Enrichment (ERD, Mermaid diagrams, optional AI summaries)
-        ↓
-    Renderers (emit format-agnostic DocNode[])
-        ↓
-    MarkdownSerializer → ADO Wiki Publisher (REST API)
-    DocxSerializer     → Word .docx file
-```
-
-Parsers only produce IR. Renderers only consume IR. Neither knows about the other — swap or add output formats without touching the parsing logic.
+- Azure DevOps Wiki — for wiki output (optional if using Word and/or PDF only)
 
 ---
 

--- a/docs/architecture.jsx
+++ b/docs/architecture.jsx
@@ -137,7 +137,7 @@ const layers = [
       { name: "Markdown Renderer", icon: "✍️", detail: "Primary output. All renderers emit markdown strings directly — string builder pattern with markdownTable() helper. toADOWikiLink() encodes all internal links (spaces→hyphens, parens escaped, hyphens→%2D). [[_TOSP_]] on container pages only.", tags: ["Primary"], done: true, moscow: "M" },
       { name: "ADO Wiki Publisher", icon: "🌐", detail: "Azure DevOps REST API. Creates/updates wiki pages in correct hierarchy. Top-down parent creation. Page name sanitisation via s() helper. Auth pre-validation. Z→A publish order for A→Z sidebar display.", tags: ["ADO"], done: true, moscow: "S" },
       { name: "Word Renderer", icon: "📄", detail: "DocNode format-agnostic document model layer (src/docmodel/nodes.ts). Renderers emit DocNode[] via MarkdownSerializer (ADO Wiki) or DocxSerializer (Word). DocxSerializer → docx library: A4 page, proportional fixed-width column tables, TOC, page-number footer. Output controlled by output.word in config or --word CLI flag. Mermaid skipped in Word (ADO-only).", tags: ["Optional"], done: true, moscow: "C" },
-      { name: "PDF Renderer", icon: "📑", detail: "Standalone PDF output separate from Word. Would reuse the DocNode layer — needs a headless rendering strategy (e.g. Puppeteer, Playwright, or a dedicated PDF library). Deferred: Word covers the primary use case.", tags: ["Optional"], done: false, moscow: "W" },
+      { name: "PDF Renderer", icon: "📑", detail: "Standalone PDF output reusing the DocNode layer — PdfSerializer (src/docmodel/PdfSerializer.ts) emits pdfmake content: A4 page, proportional fixed-width column tables (pt-based, scales the minimum down for wide tables like the security-role privilege matrix), TOC with page numbers, page-number footer. Standard 14 PDF fonts only (Helvetica/Courier) — no font files bundled; a glyph-fallback map substitutes WinAnsi-safe equivalents for symbols renderers emit outside that range (e.g. ●○ privilege dots → •°). pdfAssembler.ts mirrors docAssembler.ts section-by-section. Output controlled by output.pdf in config or --pdf CLI flag, local file only (not published to ADO Wiki). Mermaid skipped, matching Word.", tags: ["Optional"], done: true, moscow: "C" },
       { name: "Confluence Renderer", icon: "🔵", detail: "Same IR → Confluence storage format. For clients not on ADO. Low priority — most clients use ADO.", tags: ["Optional"], done: false, moscow: "W" },
     ]
   },
@@ -201,7 +201,7 @@ const decisions = [
   { q: "Package name?", a: "powerautodocs (renamed from powerautodoc)", reason: "Original package powerautodoc was published with client references in source file comments. npm does not allow full package deletion after 72 hours. Renamed to powerautodocs on a clean repository (lewginn/PowerAutoDocs) with no client data in history. Old package deprecated." },
   { q: "Security page structure?", a: "Security container → sublevel pages", reason: "Security is a container page with [[_TOSP_]]. Security Roles is a sublevel — not the top page itself — leaving room for Column Security Profiles and other future additions without restructuring the wiki hierarchy." },
   { q: "Word output?", a: "DocNode layer + DocxSerializer", reason: "Renderers now emit DocNode[] (format-agnostic). MarkdownSerializer converts to ADO Wiki markdown; DocxSerializer converts to docx Paragraph/Table elements. A4 fixed-width tables (TableLayoutType.FIXED + DXA column widths) ensure consistent rendering in Word and Word Online. Output mode controlled by output.word in config.yml or --word CLI flag. Mermaid blocks skipped in Word — ADO-only rendering." },
-  { q: "PDF output?", a: "Treated as a separate future feature", reason: "PDF rendering requires a different approach to Word (headless browser or dedicated PDF library) and has different use cases. Splitting them avoids conflating two distinct delivery formats. Word covers the primary client use case. PDF deferred." },
+  { q: "PDF output?", a: "DocNode layer + PdfSerializer (pdfmake)", reason: "Reuses the same format-agnostic DocNode[] layer as Word — PdfSerializer converts it to pdfmake content using the standard 14 PDF fonts (Helvetica/Courier), so no font files or native binaries need bundling. Mirrors DocxSerializer's structure and decisions (A4, 1\" margins, proportional column widths, Mermaid skipped) for a self-contained file. pdfAssembler.ts mirrors docAssembler.ts section-by-section with identical heading offsets. Self-contained PDFs have no subpages, so internal links degrade gracefully to plain/code-styled text — same pattern as Word. Output controlled by output.pdf in config.yml or --pdf CLI flag; local file only, not published to the ADO Wiki." },
   { q: "AI summaries — stable across runs?", a: "Cache-first: committed JSON file", reason: "A CI documentation pipeline must produce stable, reviewable output. Without a cache every run regenerates different text, creating constant noisy wiki diffs. The cache file (.powerautodocs-ai-cache.json) is committed alongside doc-gen.config.yml so AI-written summaries are reviewed in PRs before they're published — same discipline as any other code change." },
   { q: "AI summary cache invalidation?", a: "SHA-256 hash of component IR + --regenerate-ai flag", reason: "Each cache entry stores a SHA-256 of the serialised IR for that component. If the IR hasn't changed the cached summary is reused — controls API cost and prevents surprise rewrites on unchanged components. --regenerate-ai flag gives a manual escape hatch for a full fresh pass." },
   { q: "Which AI provider(s)?", a: "Anthropic (Claude) + Azure OpenAI day-one; factory-extensible", reason: "Anthropic/Claude is the natural fit given the toolchain. But most D365/Power Platform shops on ADO are deep in Azure and already have Azure OpenAI provisioned — Azure-hosted AI with data residency compliance and no new vendor procurement. Both providers implement the AiProvider interface (summarise(prompt): Promise<string>). The factory pattern in providers/index.ts means new providers (OpenAI direct, Bedrock, etc.) only need a new file — aiSummariser stays completely provider-agnostic." },
@@ -218,93 +218,93 @@ const decisions = [
   { q: "Configurable summary tone/length per client?", a: "Deferred — not in v1 scope", reason: "Adding a tone: 'technical' | 'executive' or maxSentences config knob before knowing whether clients actually want it would add config surface and prompt-variation complexity speculatively. The fixed technical-handover tone and 2-3 sentence cap covers the primary use case. Tracked as a backlog candidate — straightforward to bolt on as an optional override once the core feature is proven in real use." },
 ];
 
+// Mirrors the phase groupings tracked on the PowerAutoDocs Roadmap GitHub
+// Project (github.com/users/lewginn/projects/3) — Lewis tracks/updates issue
+// status and phase assignment there as the source of truth; this list is kept
+// in sync with it (issue numbers noted per item for traceability).
 const progress = [
   {
-    phase: "Phase 1 — Core Data Model", color: "#2563eb", status: "COMPLETE",
+    phase: "Phase 1 — Core Pipeline & Data Model", color: "#2563eb", status: "COMPLETE",
     items: [
-      { label: "Solution manifest parser", done: true },
-      { label: "Entity / table parser", done: true },
-      { label: "Column type mapping + filtering", done: true },
-      { label: "Relationship parser (1:N)", done: true },
-      { label: "IR models split by domain", done: true },
-      { label: "Barrel exports (parsers + renderers)", done: true },
-      { label: "Config system with defaults", done: true },
-      { label: "Markdown renderer", done: true },
-      { label: "Solution overview page", done: true },
-      { label: "Per-table documentation pages", done: true },
+      { label: "Solution manifest parser (#71)", done: true },
+      { label: "Entity / table parser (#72)", done: true },
+      { label: "Column type mapping + filtering (#73)", done: true },
+      { label: "Relationship parser (1:N) (#74)", done: true },
+      { label: "IR models split by domain (#75)", done: true },
+      { label: "Barrel exports — parsers + renderers (#76)", done: true },
+      { label: "Config system with defaults (#77)", done: true },
+      { label: "Markdown renderer (#78)", done: true },
+      { label: "Solution overview page (#79)", done: true },
+      { label: "Per-table documentation pages (#80)", done: true },
     ]
   },
   {
     phase: "Phase 2 — Forms, Views & Filters", color: "#7c3aed", status: "COMPLETE",
     items: [
-      { label: "Form parser (Main, Quick Create, Card)", done: true },
-      { label: "View parser with type detection", done: true },
-      { label: "View filter condition extraction", done: true },
-      { label: "Nested join filter hierarchy + depth", done: true },
-      { label: "Linked entity column prefixing", done: true },
-      { label: "Compact / detailed form layout toggle", done: true },
-      { label: "OOTB column exclusion defaults", done: true },
-      { label: "Base currency field filtering", done: true },
+      { label: "Form parser — Main, Quick Create, Card (#81)", done: true },
+      { label: "View parser with type detection (#82)", done: true },
+      { label: "View filter condition extraction (#83)", done: true },
+      { label: "Nested join filter hierarchy + depth (#84)", done: true },
+      { label: "Linked entity column prefixing (#85)", done: true },
+      { label: "Compact / detailed form layout toggle (#86)", done: true },
+      { label: "OOTB column exclusion defaults (#87)", done: true },
+      { label: "Base currency field filtering (#88)", done: true },
     ]
   },
   {
-    phase: "Phase 3 — Automation, Code & Pipeline", color: "#9333ea", status: "COMPLETE",
+    phase: "Phase 3 — Component IR Models & Renderers", color: "#9333ea", status: "COMPLETE",
     items: [
-      { label: "Flow parser — trigger types + recursive action tree", done: true },
-      { label: "Flow parser — expression serialiser for conditions", done: true },
-      { label: "Mermaid diagram generator (ADO v8.14 compatible)", done: true },
-      { label: "Classic workflow parser (XAML)", done: true },
-      { label: "Business rule parser — if/else branch extraction", done: true },
-      { label: "Table pages split into subpages (Columns/Views/Forms/Relationships/Business Rules)", done: true },
-      { label: "Plugin step parser", done: true },
-      { label: "Web Resource parser (JS)", done: true },
-      { label: "ADO Wiki REST publisher", done: true },
-      { label: "Page name sanitisation + ADO wiki link encoding", done: true },
-      { label: "npm package (powerautodocs)", done: true },
-      { label: "ADO pipeline YAML", done: true },
-      { label: "Multi-solution manifest parsing (all roles)", done: true },
-      { label: "Security role privilege matrix", done: true },
-      { label: "Environment variables parser", done: true },
-      { label: "Global choice (option set) parser", done: true },
-      { label: "Connection references parser", done: true },
-      { label: "Email template parser", done: true },
-      { label: "Model-driven app parser", done: true },
-      { label: "Mermaid ER diagram generator", done: true },
-      { label: "Run logger + summary (logger.ts)", done: true },
-      { label: "GitHub Actions npm publish workflow", done: true },
-      { label: "PCF control parser", done: false },
+      { label: "Solution Model (#37)", done: true },
+      { label: "Table & Column Model (#38)", done: true },
+      { label: "Relationship Model (#39)", done: true },
+      { label: "Form Model & Parser (#40)", done: true },
+      { label: "View Model & Parser (#41)", done: true },
+      { label: "Flow Model & Renderer (#42)", done: true },
+      { label: "Classic Workflow Model & Renderer (#43)", done: true },
+      { label: "Business Rule Model & Renderer (#44)", done: true },
+      { label: "Plugin Model & Renderer (#45)", done: true },
+      { label: "Web Resource Model & Renderer (#46)", done: true },
+      { label: "Security Role Model & Renderer (#47)", done: true },
+      { label: "Environment Variable Model & Renderer (#48)", done: true },
+      { label: "Global Choice Model & Renderer (#49)", done: true },
+      { label: "Connection Reference Model & Renderer (#50)", done: true },
+      { label: "Email Template Model & Renderer (#51)", done: true },
+      { label: "Model-Driven App Model & Renderer (#52)", done: true },
     ]
   },
   {
-    phase: "Phase 4 — Extended Components", color: "#db2777", status: "PLANNED",
+    phase: "Phase 4 — AI Enrichment & Delivery Formats", color: "#db2777", status: "IN PROGRESS",
     items: [
-      { label: "Business process flow parser", done: false },
-      { label: "Column security profile parser", done: false },
-      { label: "Routing rule set parser", done: false },
-      { label: "Custom connector parser", done: false },
-      { label: "Duplicate detection rule parser", done: false },
-      { label: "SLA parser", done: false },
-      { label: "Dashboard parser", done: false },
-      { label: "Service endpoint parser", done: false },
-      { label: "Power Pages parser", done: false },
-      { label: "PCF control parser", done: false },
+      { label: "Dependency resolver — flow ↔ table cross-links (#69)", done: true },
+      { label: "AI Enrichment Layer — summaries, caching, providers (#1) — in progress", done: false },
+      { label: "PDF renderer — DocNode + PdfSerializer + pdfAssembler, pdfmake (#67) — in progress", done: false },
     ]
   },
   {
-    phase: "Phase 5 — Advanced & Delivery", color: "#0891b2", status: "PLANNED",
+    phase: "Phase 5 — Extended Components & Configuration", color: "#0891b2", status: "PLANNED",
     items: [
-      { label: "CLI entry point (--word / --wiki flags, unknown flag detection)", done: true },
-      { label: "AI Summary Cache Manager", done: true },
-      { label: "AI Provider Interface (Anthropic/Claude)", done: true },
-      { label: "Component Summarizer (flows, plugins, rules, tables, roles)", done: false },
-      { label: "Auto-trigger pipeline (push/scheduled)", done: false },
-      { label: "Change log (git-diff driven)", done: false },
-      { label: "IR JSON artifact publishing", done: false },
-      { label: "Word renderer (DocNode layer + DocxSerializer + docAssembler)", done: true },
-      { label: "PDF renderer (headless rendering — separate from Word)", done: false },
-      { label: "Mermaid → PNG for static formats (mmdc)", done: false },
-      { label: "Dependency resolver (flow → table links)", done: false },
-      { label: "Complexity scorer", done: false },
+      { label: "Business Process Flow Model & Parser & Renderer (#54)", done: false },
+      { label: "Column Security Profile Model & Parser & Renderer (#55)", done: false },
+      { label: "Routing Rule Set Model & Parser & Renderer (#56)", done: false },
+      { label: "Custom Connector Model & Parser & Renderer (#57)", done: false },
+      { label: "Duplicate Detection Rule Model & Parser & Renderer (#58)", done: false },
+      { label: "SLA Model & Parser & Renderer (#59)", done: false },
+      { label: "Service Endpoint Model & Parser & Renderer (#61)", done: false },
+      { label: "CLI flags with commander (#63)", done: false },
+      { label: "AI Enrichment — configurable summary tone/length per client (#90)", done: false },
+    ]
+  },
+  {
+    phase: "Backlog — Future Enhancements", color: "#64748b", status: "BACKLOG",
+    items: [
+      { label: "PCF Control Model & Parser & Renderer (#53)", done: false },
+      { label: "Dashboard Model & Parser & Renderer (#60)", done: false },
+      { label: "Power Pages Model & Parser & Renderer (#62)", done: false },
+      { label: "Auto-trigger pipeline — push/scheduled (#64)", done: false },
+      { label: "Git-based changelog (#65)", done: false },
+      { label: "IR JSON artifact export (#66)", done: false },
+      { label: "Mermaid → PNG conversion (#68)", done: false },
+      { label: "Complexity scorer (#70)", done: false },
     ]
   },
 ];
@@ -354,7 +354,7 @@ export default function App() {
         <div style={{ padding: "28px 40px 0", borderBottom: "1px solid #e2e8f0", background: "#ffffff", boxShadow: "0 1px 8px rgba(0,0,0,0.06)" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
             <div style={{ background: "#0f172a", color: "white", fontFamily: "'IBM Plex Sans', sans-serif", fontWeight: 600, fontSize: 11, padding: "3px 10px", borderRadius: 2, letterSpacing: "0.12em" }}>POWERAUTODOCS</div>
-            <span style={{ fontSize: 9, color: "#64748b", letterSpacing: "0.1em", fontFamily: "'IBM Plex Mono', monospace" }}>v1.2.0</span>
+            <span style={{ fontSize: 9, color: "#64748b", letterSpacing: "0.1em", fontFamily: "'IBM Plex Mono', monospace" }}>v1.3.0</span>
             <a href="https://github.com/users/lewginn/projects/3" style={{ fontSize: 9, color: "#2563eb", marginLeft: "auto", textDecoration: "none" }}>→ Track in GitHub Project</a>
           </div>
           <h1 style={{ fontFamily: "'IBM Plex Sans', sans-serif", fontSize: 22, fontWeight: 300, color: "#0f172a", letterSpacing: "-0.01em", marginBottom: 6 }}>
@@ -374,7 +374,7 @@ export default function App() {
               <span style={{ color: "#0f172a", fontWeight: 600 }}>{doneComponents}</span>
               <span style={{ color: "#94a3b8" }}>/{totalComponents}</span>
               <span> components built &nbsp;·&nbsp; </span>
-              <span style={{ color: "#059669", fontWeight: 600 }}>Phases 1, 2 & 3 complete · Phase 4 planned</span>
+              <span style={{ color: "#059669", fontWeight: 600 }}>Phases 1, 2 & 3 complete · Phase 4 in progress · Phase 5 & Backlog planned</span>
             </span>
           </div>
           <div style={{ display: "flex", gap: 0 }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerautodocs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerautodocs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",
@@ -18,6 +18,7 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "openai": "^6.42.0",
+        "pdfmake": "^0.2.23",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -26,6 +27,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.3.3",
+        "@types/pdfmake": "^0.2.13",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       },
@@ -505,6 +507,51 @@
         "node": ">=18"
       }
     },
+    "node_modules/@foliojs-fork/fontkit": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
+      "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/restructure": "^2.0.2",
+        "brotli": "^1.2.0",
+        "clone": "^1.0.4",
+        "deep-equal": "^1.0.0",
+        "dfa": "^1.2.0",
+        "tiny-inflate": "^1.0.2",
+        "unicode-properties": "^1.2.2",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/linebreak": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
+      "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/pdfkit": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
+      "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/fontkit": "^1.9.2",
+        "@foliojs-fork/linebreak": "^1.1.1",
+        "crypto-js": "^4.2.0",
+        "jpeg-exif": "^1.1.4",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/restructure": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
+      "license": "MIT"
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -525,6 +572,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+      "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pdfmake": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.13.tgz",
+      "integrity": "sha512-QzOwk3dMTZOwVbDZNHGIQcpwBgprp1y1vzRBmR+p+vMtCZo00G1CN+YhNebkygtmaGjdzvyXJVOHMEuTbvhJ8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pdfkit": "*"
       }
     },
     "node_modules/adm-zip": {
@@ -551,6 +619,12 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -561,6 +635,80 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/commander": {
@@ -578,6 +726,72 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/docx": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
@@ -593,6 +807,50 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -689,6 +947,61 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -719,6 +1032,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -740,6 +1065,45 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -748,6 +1112,34 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/immediate": {
@@ -762,10 +1154,67 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -821,6 +1270,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -886,6 +1344,31 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/openai": {
       "version": "6.42.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
@@ -926,6 +1409,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pdfmake": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.23.tgz",
+      "integrity": "sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/linebreak": "^1.1.2",
+        "@foliojs-fork/pdfkit": "^0.15.3",
+        "iconv-lite": "^0.7.1",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -947,6 +1453,26 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -963,6 +1489,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -970,6 +1502,38 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -1016,6 +1580,12 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/ts-algebra": {
@@ -1077,6 +1647,32 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1105,6 +1701,18 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.3",
+    "@types/pdfmake": "^0.2.13",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
@@ -39,6 +40,7 @@
     "handlebars": "^4.7.8",
     "js-yaml": "^4.1.1",
     "openai": "^6.42.0",
+    "pdfmake": "^0.2.23",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/samples/doc-gen.config.sample.yml
+++ b/samples/doc-gen.config.sample.yml
@@ -10,7 +10,7 @@
 # -----------------------------------------------------------------------------
 # SOLUTIONS
 # List every unpacked Power Platform solution you want to document.
-# All solutions are merged into a single output (wiki and/or Word).
+# All solutions are merged into a single output (wiki, Word and/or PDF).
 # -----------------------------------------------------------------------------
 solutions:
   - path: ./unpacked/MySolution       # Path to the unpacked solution folder
@@ -25,8 +25,8 @@ solutions:
 
 # -----------------------------------------------------------------------------
 # OUTPUT
-# Control what gets generated. You can enable wiki, Word, or both.
-# CLI flags --wiki and --word override these settings at runtime.
+# Control what gets generated. You can enable wiki, Word, PDF, or any combination.
+# CLI flags --wiki, --word and --pdf override these settings at runtime.
 # -----------------------------------------------------------------------------
 output:
   path: ./output                      # Local folder for generated files
@@ -34,6 +34,9 @@ output:
   wiki: true                          # Publish to Azure DevOps Wiki
   word: true                          # Generate a Word (.docx) document
   wordFilename: solution-documentation.docx  # Word output filename
+
+  pdf: false                          # Generate a PDF document (local file only — not published to ADO Wiki)
+  pdfFilename: solution-documentation.pdf    # PDF output filename
 
 
 # -----------------------------------------------------------------------------

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -30,6 +30,8 @@ export const CONFIG_DEFAULTS: DocGenConfig = {
     wiki: true,
     word: true,
     wordFilename: 'solution-documentation.docx',
+    pdf: false,
+    pdfFilename: 'solution-documentation.pdf',
   },
   parse: {
     customColumnsOnly: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -89,6 +89,10 @@ export interface DocGenConfig {
     word?: boolean;
     /** Filename for the Word document (default: 'solution-documentation.docx') */
     wordFilename?: string;
+    /** Generate a PDF document. Default: false */
+    pdf?: boolean;
+    /** Filename for the PDF document (default: 'solution-documentation.pdf') */
+    pdfFilename?: string;
   };
 
   parse: {

--- a/src/docmodel/DocxSerializer.ts
+++ b/src/docmodel/DocxSerializer.ts
@@ -188,9 +188,16 @@ export function serializeBlock(node: DocNode, headingOffset: number): DocxBlock 
     case 'heading': {
       const absLevel  = Math.min(node.level + headingOffset, 4);
       const spacing   = HEADING_SPACING[absLevel] ?? HEADING_SPACING[4];
+      // Forcing a page break before every top-level section heading left large
+      // dead zones whenever the prior section ended partway down a page (e.g.
+      // the Overview's Solutions table finishing a third of the way down, then
+      // "Data Model" punting the rest of the page to whitespace). Letting
+      // sections flow naturally — same as everything else in the document —
+      // removes that wasted space; Word still keeps headings from being
+      // orphaned at the bottom of a page via `keepNext` below.
       return new Paragraph({
         heading: resolveHeadingLevel(node.level, headingOffset),
-        pageBreakBefore: absLevel === 1,
+        keepNext: true,
         children: [new TextRun({ text: node.text, italics: false })],
         spacing,
       });

--- a/src/docmodel/PdfSerializer.ts
+++ b/src/docmodel/PdfSerializer.ts
@@ -1,0 +1,419 @@
+// src/docmodel/PdfSerializer.ts
+//
+// Converts DocNode[] → pdfmake document content.
+// headingOffset is added to every heading level (used by pdfAssembler).
+// Mirrors DocxSerializer's structure and decisions (A4, 1" margins,
+// proportional column widths, Mermaid skipped) for a self-contained PDF.
+
+import PdfPrinter from 'pdfmake';
+import type { Content, TDocumentDefinitions, TableCell } from 'pdfmake/interfaces.js';
+import type { DocNode, InlineNode, BulletItem } from './nodes.js';
+
+// -----------------------------------------------
+// Page geometry — A4, 1" margins (matches DocxSerializer)
+// -----------------------------------------------
+
+const PT_PER_INCH      = 72;
+const PAGE_MARGIN_PT   = PT_PER_INCH;                  // 1"
+const PAGE_WIDTH_PT    = 595.28;                       // A4 width in pt
+const CONTENT_WIDTH_PT = PAGE_WIDTH_PT - PAGE_MARGIN_PT * 2;
+
+// Standard 14 PDF fonts — no font files to bundle.
+const FONTS = {
+  Helvetica: {
+    normal:      'Helvetica',
+    bold:        'Helvetica-Bold',
+    italics:     'Helvetica-Oblique',
+    bolditalics: 'Helvetica-BoldOblique',
+  },
+  Courier: {
+    normal:      'Courier',
+    bold:        'Courier-Bold',
+    italics:     'Courier-Oblique',
+    bolditalics: 'Courier-BoldOblique',
+  },
+};
+
+// -----------------------------------------------
+// Inline serialisation
+// -----------------------------------------------
+
+/**
+ * The standard 14 PDF fonts (Helvetica/Courier) only support WinAnsi-encoded
+ * glyphs — no font files are bundled with the package (see "How pdfmake was
+ * chosen" in PR discussion: avoids shipping TTFs / native binaries). Renderers
+ * occasionally emit Unicode symbols (e.g. the ●○ privilege-level dots in
+ * securityRoleRenderer) that fall outside that range and render as garbage
+ * glyphs. Substitute the closest WinAnsi-safe equivalents here so the PDF
+ * stays self-contained without pulling in a Unicode font.
+ */
+const GLYPH_FALLBACKS: Record<string, string> = {
+  '●': '•', // ● BLACK CIRCLE      → • BULLET
+  '○': '°', // ○ WHITE CIRCLE      → ° DEGREE SIGN (closest hollow-circle glyph in WinAnsi)
+};
+
+const GLYPH_PATTERN = new RegExp(`[${Object.keys(GLYPH_FALLBACKS).join('')}]`, 'g');
+
+/** Replace Unicode glyphs the standard PDF fonts can't render with WinAnsi-safe equivalents. */
+function sanitiseForPdf(text: string): string {
+  return GLYPH_PATTERN.test(text)
+    ? text.replace(GLYPH_PATTERN, ch => GLYPH_FALLBACKS[ch] ?? ch)
+    : text;
+}
+
+function inlineRuns(inlines: InlineNode[]): Content[] {
+  return inlines.map((node): Content => {
+    switch (node.type) {
+      case 'text':
+        return { text: sanitiseForPdf(node.value) };
+      case 'code':
+        return { text: sanitiseForPdf(node.value), font: 'Courier', fontSize: 9 };
+      case 'bold':
+        return { text: sanitiseForPdf(node.value), bold: true };
+      case 'italic':
+        return { text: sanitiseForPdf(node.value), italics: true };
+      case 'link':
+        // Render as plain text — no subpage hyperlinks in a self-contained PDF
+        return { text: sanitiseForPdf(node.text) };
+    }
+  });
+}
+
+/** Flatten InlineNode[] to a plain string (used for column width measurement). */
+function inlinesToText(inlines: InlineNode[]): string {
+  return inlines.map(n => {
+    switch (n.type) {
+      case 'text':   return n.value;
+      case 'code':   return n.value;
+      case 'bold':   return n.value;
+      case 'italic': return n.value;
+      case 'link':   return n.text;
+    }
+  }).join('');
+}
+
+// -----------------------------------------------
+// Heading styles
+// -----------------------------------------------
+
+const HEADING_STYLES: Record<number, string> = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+  4: 'h4',
+};
+
+function resolveHeadingLevel(level: number, offset: number): number {
+  return Math.min(level + offset, 4);
+}
+
+// -----------------------------------------------
+// Column width calculation — proportional to content (mirrors DocxSerializer)
+// -----------------------------------------------
+
+const COL_MAX_CHARS = 35;
+// Wide enough that bold 10pt header words like "Managed" or "Version" don't
+// wrap mid-word (narrower than DocxSerializer's twips-based minimum because
+// Word can shrink column padding further than pdfmake's fixed cell margins).
+const COL_MIN_PT    = 60;
+
+// Heuristic average glyph width for 10pt Helvetica — used to estimate how wide
+// a column needs to be to fit its longest *unbreakable* word without pdfmake
+// hard-breaking it mid-character (e.g. "ShowHideGenerateInvoiceButton",
+// "Synchronous", "OpportunityEnrolmentCondition", or "Append" in a bold header).
+// pdfmake has no hyphenation for the standard 14 fonts, so this is the only
+// lever — slightly generous to account for bold headers being wider than body text.
+// Bold table headers are noticeably wider than 10pt regular body text — sized
+// generously enough to cover Helvetica-Bold glyph widths so headers like
+// "Append" don't wrap mid-word either (a slight over-estimate for body text
+// just means a touch more breathing room, which is harmless).
+const AVG_CHAR_WIDTH_PT = 6.2;
+const CELL_HPADDING_PT  = 8; // matches the [4, 3, 4, 3] cell margin (left + right)
+
+/** Length of the longest contiguous non-whitespace run in a string. */
+function longestWordLength(text: string): number {
+  let max = 0;
+  for (const word of text.split(/\s+/)) {
+    if (word.length > max) max = word.length;
+  }
+  return max;
+}
+
+/** Longest unbreakable word across a header + its column's body cells, in points. */
+function longestWordWidth(header: string, columnIndex: number, rows: InlineNode[][][]): number {
+  let longest = longestWordLength(header);
+  for (const row of rows) {
+    longest = Math.max(longest, longestWordLength(inlinesToText(row[columnIndex] ?? [])));
+  }
+  return longest * AVG_CHAR_WIDTH_PT + CELL_HPADDING_PT;
+}
+
+function calcColumnWidths(headers: string[], rows: InlineNode[][][]): number[] {
+  const rawMax = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map(row => inlinesToText(row[i] ?? []).length), 3)
+  );
+  const clamped  = rawMax.map(w => Math.min(w, COL_MAX_CHARS));
+  const total    = clamped.reduce((a, b) => a + b, 0);
+  const desired  = clamped.map(w => (w / total) * CONTENT_WIDTH_PT);
+
+  // Wide tables (e.g. the security-role privilege matrix has 9 columns) can't
+  // all honour COL_MIN_PT without overflowing the page — shrink the floor
+  // proportionally to the number of columns so it never exceeds an equal split.
+  // Each column's floor is then raised (up to half the page width) to fit its
+  // longest unbreakable word, so identifiers/entity names/headers like
+  // "Append To" wrap at word boundaries instead of mid-character.
+  const baseMin = Math.min(COL_MIN_PT, CONTENT_WIDTH_PT / headers.length);
+  const colMins = headers.map((h, i) =>
+    Math.min(Math.max(baseMin, longestWordWidth(h, i, rows)), CONTENT_WIDTH_PT / 2)
+  );
+
+  // Never start below a column's own minimum — `target` is what each column
+  // would get if space were unlimited.
+  const target    = desired.map((d, i) => Math.max(d, colMins[i]));
+  const targetSum = target.reduce((a, b) => a + b, 0);
+
+  let widths: number[];
+  if (targetSum <= CONTENT_WIDTH_PT) {
+    // Room to spare — hand the surplus to columns proportionally to how much
+    // content they're carrying (so text-heavy columns benefit most), without
+    // ever taking a column below its own minimum (only `desired`-driven
+    // columns absorb the surplus split).
+    const surplus = CONTENT_WIDTH_PT - targetSum;
+    const driverIdx = target.map((t, i) => t === desired[i] && desired[i] > colMins[i] ? i : -1).filter(i => i >= 0);
+    const driverSum = driverIdx.reduce((s, i) => s + desired[i], 0);
+    widths = target.slice();
+    if (driverIdx.length > 0 && driverSum > 0) {
+      driverIdx.forEach(i => { widths[i] += surplus * (desired[i] / driverSum); });
+    } else {
+      // No column has room above its minimum to grow into — split evenly.
+      widths = widths.map(w => w + surplus / widths.length);
+    }
+  } else {
+    // Minimums alone don't fit — shrink columns that have headroom above
+    // their own minimum first; only scale minimums down (last resort,
+    // unavoidable wrapping) if that still isn't enough.
+    const minSum = colMins.reduce((a, b) => a + b, 0);
+    if (minSum <= CONTENT_WIDTH_PT) {
+      const shrinkable = target.map((t, i) => t - colMins[i]);
+      const shrinkableSum = shrinkable.reduce((a, b) => a + b, 0);
+      const overflow = targetSum - CONTENT_WIDTH_PT;
+      widths = target.map((t, i) =>
+        shrinkableSum > 0 ? t - overflow * (shrinkable[i] / shrinkableSum) : t
+      );
+    } else {
+      // Even the minimums don't fit (e.g. a 9-column privilege matrix where
+      // "Entity" needs real room for long names like "ApplicationStatusHistory").
+      // Scaling every column down proportionally would shrink short headers
+      // ("Create", "Append") below their own minimum too — wrapping them all.
+      // Instead, protect every column's minimum except the single widest one,
+      // which absorbs the entire shortfall: it already wraps long entity names
+      // onto multiple lines gracefully, so it's the least-bad place to compress.
+      const widestIdx = colMins.reduce((best, m, i) => m > colMins[best] ? i : best, 0);
+      const othersSum = minSum - colMins[widestIdx];
+      widths = colMins.slice();
+      widths[widestIdx] = Math.max(CONTENT_WIDTH_PT - othersSum, baseMin);
+    }
+  }
+
+  const final = widths.map(w => Math.floor(w));
+  const allocated = final.reduce((a, b) => a + b, 0);
+  final[final.length - 1] += CONTENT_WIDTH_PT - allocated;
+  return final;
+}
+
+// -----------------------------------------------
+// Table serialisation
+// -----------------------------------------------
+
+function serializeTable(headers: string[], rows: InlineNode[][][]): Content {
+  const colWidths = calcColumnWidths(headers, rows);
+
+  // Some renderers emit borderless N-column "grid" layouts via empty header
+  // strings (e.g. modelDrivenAppRenderer's Custom/Standard Entities lists).
+  // Markdown/Word simply have no visible header row for these — but pdfmake
+  // always shades headerRows, so an all-empty header would render as a bare
+  // grey strip. Detect that case and render a plain body-only table instead.
+  const hasVisibleHeader = headers.some(h => h.trim() !== '');
+
+  const bodyRows: TableCell[][] = rows.map(row =>
+    row.map((cell): TableCell => ({
+      stack: [{ text: inlineRuns(cell), margin: [0, 0, 0, 0] }],
+      margin: [4, 3, 4, 3],
+    }))
+  );
+
+  if (!hasVisibleHeader) {
+    return {
+      table: {
+        widths: colWidths,
+        body: bodyRows,
+      },
+      layout: {
+        hLineWidth:  () => 0.5,
+        vLineWidth:  () => 0.5,
+        hLineColor:  () => '#CCCCCC',
+        vLineColor:  () => '#CCCCCC',
+      },
+      margin: [0, 0, 0, 12],
+    };
+  }
+
+  const headerRow: TableCell[] = headers.map(h => ({
+    text: sanitiseForPdf(h),
+    bold: true,
+    fillColor: '#E8E8E8',
+    margin: [4, 3, 4, 3],
+  }));
+
+  return {
+    table: {
+      headerRows: 1,
+      widths: colWidths,
+      body: [headerRow, ...bodyRows],
+    },
+    layout: {
+      hLineWidth:  () => 0.5,
+      vLineWidth:  () => 0.5,
+      hLineColor:  () => '#CCCCCC',
+      vLineColor:  () => '#CCCCCC',
+    },
+    margin: [0, 0, 0, 12],
+  };
+}
+
+// -----------------------------------------------
+// Bullet list serialisation
+// -----------------------------------------------
+
+/**
+ * pdfmake's `ul` only nests via nested `ul` arrays, not a flat depth value —
+ * group consecutive items by depth into nested lists.
+ */
+function nestBulletItems(items: BulletItem[], depth = 0): Content[] {
+  const result: Content[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const item = items[i];
+    if (item.depth === depth) {
+      result.push({ text: inlineRuns(item.inlines) });
+      i++;
+    } else if (item.depth > depth) {
+      const start = i;
+      while (i < items.length && items[i].depth > depth) i++;
+      result.push({ ul: nestBulletItems(items.slice(start, i), depth + 1) });
+    } else {
+      break;
+    }
+  }
+  return result;
+}
+
+// -----------------------------------------------
+// Block serialisation
+// -----------------------------------------------
+
+export function serializeBlock(node: DocNode, headingOffset: number): Content | null {
+  switch (node.type) {
+    case 'heading': {
+      const absLevel = resolveHeadingLevel(node.level, headingOffset);
+      return {
+        text: sanitiseForPdf(node.text),
+        style: HEADING_STYLES[absLevel] ?? 'h4',
+        // Forcing a page break before every top-level section heading (the old
+        // `pageBreak: absLevel === 1 ? 'before' : undefined`) left large dead
+        // zones whenever the prior section ended partway down a page — e.g. the
+        // Overview's Solutions table finishing a third of the way down, then
+        // "Data Model" punting the rest of that page to whitespace. Letting
+        // sections flow naturally, same as every other heading level, removes
+        // that wasted space.
+        tocItem: absLevel <= 3,
+        tocStyle: { fontSize: 10 },
+      };
+    }
+
+    case 'paragraph':
+      return { text: inlineRuns(node.inlines), margin: [0, 0, 0, 8] };
+
+    case 'table':
+      return serializeTable(node.headers, node.rows);
+
+    case 'bullet_list':
+      return { ul: nestBulletItems(node.items), margin: [0, 0, 0, 8] };
+
+    case 'mermaid':
+      // Mermaid diagrams are only rendered in ADO Wiki — skip in PDF output (matches Word)
+      return null;
+
+    case 'code_block':
+      return {
+        text: sanitiseForPdf(node.text),
+        font: 'Courier',
+        fontSize: 9,
+        preserveLeadingSpaces: true,
+        margin: [0, 0, 0, 8],
+      };
+
+    case 'blockquote':
+      return {
+        text: inlineRuns(node.inlines),
+        italics: true,
+        margin: [16, 0, 0, 8],
+      };
+
+    case 'toc_placeholder':
+      return null;
+  }
+}
+
+// -----------------------------------------------
+// Public API
+// -----------------------------------------------
+
+export function serializeBlocks(nodes: DocNode[], headingOffset = 0): Content[] {
+  return nodes
+    .map(node => serializeBlock(node, headingOffset))
+    .filter((block): block is Content => block !== null);
+}
+
+export function buildToc(): Content {
+  return {
+    toc: {
+      title: { text: 'Table of Contents', style: 'h1' },
+    },
+    pageBreak: 'after',
+  };
+}
+
+export function buildDocDefinition(content: Content[]): TDocumentDefinitions {
+  return {
+    pageSize: 'A4',
+    pageMargins: [PAGE_MARGIN_PT, PAGE_MARGIN_PT, PAGE_MARGIN_PT, PAGE_MARGIN_PT],
+    defaultStyle: { font: 'Helvetica', fontSize: 10 },
+    styles: {
+      h1: { fontSize: 20, bold: true, margin: [0, 0, 0, 12] },
+      h2: { fontSize: 16, bold: true, margin: [0, 14, 0, 8] },
+      h3: { fontSize: 13, bold: true, margin: [0, 10, 0, 6] },
+      h4: { fontSize: 11, bold: true, margin: [0, 8, 0, 4] },
+    },
+    footer: (currentPage: number, pageCount: number) => ({
+      text: `Page ${currentPage} of ${pageCount}`,
+      alignment: 'center',
+      fontSize: 9,
+      margin: [0, 8, 0, 0],
+    }),
+    content,
+  };
+}
+
+export function toBuffer(docDefinition: TDocumentDefinitions): Promise<Buffer> {
+  const printer = new PdfPrinter(FONTS);
+  const doc = printer.createPdfKitDocument(docDefinition);
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+    doc.end();
+  });
+}

--- a/src/enrichment/dependencyResolver.ts
+++ b/src/enrichment/dependencyResolver.ts
@@ -1,0 +1,77 @@
+// enrichment/dependencyResolver.ts
+//
+// Cross-references Power Automate Flows against Dataverse Tables to surface
+// which flows touch which tables — purely derived from already-parsed IR,
+// returned as lookup maps (matches the erdGenerator pattern: read-only IR in,
+// derived data out — nothing is mutated on the IR objects).
+
+import type { FlowModel, TableModel } from '../ir/index.js';
+
+export interface FlowTableDependencies {
+  /** Table logical name (lowercase) → flows that reference it */
+  tableToFlows: Map<string, FlowModel[]>;
+  /** Flow id → tables it references */
+  flowToTables: Map<string, TableModel[]>;
+}
+
+/**
+ * Dataverse connector actions reference entities by their (often plural)
+ * entity-set name — e.g. `opportunities`, `vel_approvals` — while
+ * TableModel.logicalName is singular (`opportunity`, `vel_approval`). These
+ * candidates cover the common English pluralisation patterns Dataverse's
+ * default entity-set naming follows, so a plural reference still resolves to
+ * its singular logical name.
+ */
+function singularCandidates(name: string): string[] {
+  const candidates = [name];
+  if (name.endsWith('ies') && name.length > 3) candidates.push(name.slice(0, -3) + 'y');
+  if (name.endsWith('ses') && name.length > 3) candidates.push(name.slice(0, -2));
+  if (name.endsWith('es') && name.length > 2) candidates.push(name.slice(0, -2));
+  if (name.endsWith('s') && name.length > 1) candidates.push(name.slice(0, -1));
+  return candidates;
+}
+
+/**
+ * Matches each flow's trigger entity and action entityName fields against
+ * the solution's TableModels by logical name (case-insensitive, with a
+ * singular/plural fallback). Flows that don't reference any table present in
+ * this solution are omitted from both maps — most Dataverse tables a flow
+ * touches are standard/uncustomised and won't have a TableModel here.
+ */
+export function resolveFlowTableDependencies(
+  flows: FlowModel[],
+  tables: TableModel[]
+): FlowTableDependencies {
+  const tableByLogicalName = new Map(tables.map(t => [t.logicalName.toLowerCase(), t]));
+
+  const tableToFlows = new Map<string, FlowModel[]>();
+  const flowToTables = new Map<string, TableModel[]>();
+
+  for (const flow of flows) {
+    const entityNames = new Set<string>();
+    if (flow.trigger.entity) entityNames.add(flow.trigger.entity.toLowerCase());
+    for (const action of flow.actions) {
+      if (action.entityName) entityNames.add(action.entityName.toLowerCase());
+    }
+
+    const matchedTables: TableModel[] = [];
+    for (const entityName of entityNames) {
+      const table = singularCandidates(entityName)
+        .map(candidate => tableByLogicalName.get(candidate))
+        .find((t): t is TableModel => t !== undefined);
+      if (!table) continue;
+
+      matchedTables.push(table);
+
+      const existing = tableToFlows.get(table.logicalName.toLowerCase()) ?? [];
+      existing.push(flow);
+      tableToFlows.set(table.logicalName.toLowerCase(), existing);
+    }
+
+    if (matchedTables.length > 0) {
+      flowToTables.set(flow.id, matchedTables);
+    }
+  }
+
+  return { tableToFlows, flowToTables };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { enrichWithAiSummaries } from './enrichment/aiSummariser.js';
 import { publishToWiki } from './publisher/wikiPublisher.js';
 import { buildWikiPages } from './publisher/wikiAssembler.js';
 import { buildWordDocument } from './publisher/docAssembler.js';
+import { buildPdfDocument } from './publisher/pdfAssembler.js';
 import { log, logHeader, logSummary, createSummary } from './logger.js';
 import type { RunSummary } from './logger.js';
 
@@ -72,14 +73,15 @@ export async function main(configDir?: string): Promise<void> {
   const argv     = process.argv.slice(2);
   const flagWord = argv.includes('--word');
   const flagWiki = argv.includes('--wiki');
+  const flagPdf  = argv.includes('--pdf');
   const flagRegenerateAi = argv.includes('--regenerate-ai');
 
-  const KNOWN_FLAGS = new Set(['--word', '--wiki', '--regenerate-ai']);
+  const KNOWN_FLAGS = new Set(['--word', '--wiki', '--pdf', '--regenerate-ai']);
   const unknownFlags = argv.filter(a => a.startsWith('--') && !KNOWN_FLAGS.has(a));
   if (unknownFlags.length > 0) {
     console.error(`✗ Unknown flag(s): ${unknownFlags.join(', ')}`);
-    console.error('  Valid flags: --word  --wiki  --regenerate-ai');
-    console.error('  Or set output.wiki / output.word in doc-gen.config.yml instead.');
+    console.error('  Valid flags: --word  --wiki  --pdf  --regenerate-ai');
+    console.error('  Or set output.wiki / output.word / output.pdf in doc-gen.config.yml instead.');
     process.exit(1);
   }
 
@@ -95,14 +97,17 @@ export async function main(configDir?: string): Promise<void> {
   }
 
   // Apply CLI flag overrides (local dev convenience — pipeline uses config only).
-  // If either flag is passed, treat them as the explicit output selection:
-  //   --word        → Word only, suppress wiki even if config.wiki is set
-  //   --wiki        → Wiki only, suppress Word even if config has output.word: true
-  //   --word --wiki → both
-  //   (no flags)    → fall through to whatever the config says
-  if (flagWord || flagWiki) {
+  // If any output flag is passed, treat them as the explicit output selection —
+  // unlisted formats are suppressed even if enabled in config:
+  //   --word               → Word only
+  //   --wiki               → Wiki only
+  //   --pdf                → PDF only
+  //   --word --wiki --pdf  → any combination
+  //   (no flags)           → fall through to whatever the config says
+  if (flagWord || flagWiki || flagPdf) {
     config.output.word = flagWord;
     config.output.wiki = flagWiki;
+    config.output.pdf  = flagPdf;
     if (flagWiki && !config.wiki) {
       log('warn', '--wiki flag set but no wiki config in doc-gen.config.yml — skipping wiki publish');
     }
@@ -396,6 +401,36 @@ export async function main(configDir?: string): Promise<void> {
     } catch (err: any) {
       log('error', `Word document generation failed — ${err?.message ?? err}`);
       summary.publishFailures.push({ path: wordOutputPath, reason: err?.message ?? String(err) });
+    }
+  }
+
+  // ---- PDF document ----
+  if (config.output.pdf && mergedSolution) {
+    logHeader('Generating PDF document');
+    const pdfFilename = config.output.pdfFilename ?? 'solution-documentation.pdf';
+    const pdfOutputPath = path.join(config.output.path, pdfFilename);
+    try {
+      await buildPdfDocument(
+        config,
+        allSolutions,
+        mergedSolution,
+        allFlows,
+        allPluginAssemblies,
+        allWebResources,
+        allClassicWorkflows,
+        allBusinessRules,
+        allSecurityRoles,
+        allEnvVars,
+        allConnectionReferences,
+        allGlobalChoices,
+        allEmailTemplates,
+        allModelDrivenApps,
+        pdfOutputPath,
+      );
+      log('success', `PDF document written: ${pdfOutputPath}`);
+    } catch (err: any) {
+      log('error', `PDF document generation failed — ${err?.message ?? err}`);
+      summary.publishFailures.push({ path: pdfOutputPath, reason: err?.message ?? String(err) });
     }
   }
 

--- a/src/publisher/pdfAssembler.ts
+++ b/src/publisher/pdfAssembler.ts
@@ -1,8 +1,8 @@
-// src/publisher/docAssembler.ts
+// src/publisher/pdfAssembler.ts
 //
-// Assembles all IR into a single Word document.
-// Mirrors the section structure of wikiAssembler, but instead of WikiPage[]
-// it produces one flat array of docx blocks — one continuous document.
+// Assembles all IR into a single PDF document.
+// Mirrors docAssembler.ts section-by-section — same structure, same heading
+// offsets — but emits pdfmake content via PdfSerializer instead of docx blocks.
 //
 // Heading offsets:
 //   depth 0 (section titles: Data Model, Automation, etc.)  → offset 0  → h1 stays h1
@@ -19,10 +19,10 @@ import type {
 } from '../ir/index.js';
 import { generateERDiagram } from '../enrichment/erdGenerator.js';
 import { resolveFlowTableDependencies } from '../enrichment/dependencyResolver.js';
-import { serializeBlocks, buildDocument, buildToc, toBuffer } from '../docmodel/DocxSerializer.js';
-import { h, toc, mermaid, pt } from '../docmodel/nodes.js';
+import { serializeBlocks, buildDocDefinition, buildToc, toBuffer } from '../docmodel/PdfSerializer.js';
+import { h, mermaid, pt } from '../docmodel/nodes.js';
 import type { DocNode } from '../docmodel/nodes.js';
-import type { Paragraph, Table, TableOfContents } from 'docx';
+import type { Content } from 'pdfmake/interfaces.js';
 import {
   renderOverview,
   renderTableIndex, renderTableColumns, renderTableViews,
@@ -40,25 +40,23 @@ import {
   renderModelDrivenAppsIndex, renderModelDrivenAppPage,
 } from '../renderers/index.js';
 
-type Block = Paragraph | Table | TableOfContents;
-
 /**
- * Mermaid diagrams are skipped in Word output (DocxSerializer returns [] for
- * `mermaid` nodes). Renderers shared with the wiki — e.g. renderSingleFlow's
- * "Diagram" section — emit a heading immediately before the diagram, which
- * would otherwise be left dangling with nothing beneath it. Drop any heading
- * that's directly followed by a mermaid node.
+ * Mermaid diagrams are skipped in PDF output (PdfSerializer returns null for
+ * `mermaid` nodes, matching Word). Renderers shared with the wiki — e.g.
+ * renderSingleFlow's "Diagram" section — emit a heading immediately before
+ * the diagram, which would otherwise be left dangling with nothing beneath it.
+ * Drop any heading that's directly followed by a mermaid node.
  */
 function dropOrphanedDiagramHeadings(nodes: DocNode[]): DocNode[] {
   return nodes.filter((node, i) => !(node.type === 'heading' && nodes[i + 1]?.type === 'mermaid'));
 }
 
-/** Add nodes to the block array at a given heading offset. */
-function push(blocks: Block[], nodes: DocNode[], offset: number): void {
-  blocks.push(...serializeBlocks(dropOrphanedDiagramHeadings(nodes), offset));
+/** Add nodes to the content array at a given heading offset. */
+function push(content: Content[], nodes: DocNode[], offset: number): void {
+  content.push(...serializeBlocks(dropOrphanedDiagramHeadings(nodes), offset));
 }
 
-export async function buildWordDocument(
+export async function buildPdfDocument(
   config: DocGenConfig,
   solutions: SolutionModel[],
   mergedSolution: SolutionModel,
@@ -75,13 +73,13 @@ export async function buildWordDocument(
   modelDrivenApps: ModelDrivenAppModel[] = [],
   outputPath: string,
 ): Promise<void> {
-  const blocks: Block[] = [];
+  const content: Content[] = [];
 
   // ---- Table of Contents ----
-  blocks.push(buildToc());
+  content.push(buildToc());
 
   // ---- Overview ---- (depth 0)
-  push(blocks, renderOverview(
+  push(content, renderOverview(
     solutions, flows, pluginAssemblies.filter(a => a.assemblyName.trim() !== ''),
     webResources, classicWorkflows, businessRules,
     securityRoles, envVars, globalChoices,
@@ -93,8 +91,8 @@ export async function buildWordDocument(
     ? generateERDiagram(mergedSolution.tables, solutions[0]?.publisher?.prefix ?? '', config.erd)
     : generateERDiagram(mergedSolution.tables, undefined, config.erd);
 
-  push(blocks, [h(1, 'Data Model')], 0);
-  if (erdDiagram) push(blocks, [mermaid(erdDiagram)], 0);
+  push(content, [h(1, 'Data Model')], 0);
+  if (erdDiagram) push(content, [mermaid(erdDiagram)], 0);
 
   const flowDeps = resolveFlowTableDependencies(flows, mergedSolution.tables);
 
@@ -105,26 +103,26 @@ export async function buildWordDocument(
     const tableFlows = flowDeps.tableToFlows.get(table.logicalName.toLowerCase()) ?? [];
 
     // Table index (drop toc_placeholder — content follows inline)
-    push(blocks, renderTableIndex(table).filter(n => n.type !== 'toc_placeholder'), 1);
-    push(blocks, renderTableColumns(table), 2);
+    push(content, renderTableIndex(table).filter(n => n.type !== 'toc_placeholder'), 1);
+    push(content, renderTableColumns(table), 2);
 
     if (config.components.views) {
-      push(blocks, renderTableViews(table), 2);
+      push(content, renderTableViews(table), 2);
     }
     if (config.components.forms) {
-      push(blocks, renderTableForms(table, config), 2);
+      push(content, renderTableForms(table, config), 2);
     }
     if (config.components.relationships) {
-      push(blocks, renderTableRelationships(table), 2);
+      push(content, renderTableRelationships(table), 2);
     }
     if (tableFlows.length > 0) {
-      push(blocks, renderTableUsedByFlows(table, tableFlows), 2);
+      push(content, renderTableUsedByFlows(table, tableFlows), 2);
     }
 
     if (tableRules.length > 0) {
-      push(blocks, renderTableBusinessRules(table, tableRules).filter(n => n.type !== 'toc_placeholder'), 2);
+      push(content, renderTableBusinessRules(table, tableRules).filter(n => n.type !== 'toc_placeholder'), 2);
       for (const rule of tableRules) {
-        push(blocks, renderSingleBusinessRule(rule), 3);
+        push(content, renderSingleBusinessRule(rule), 3);
       }
     }
   }
@@ -136,33 +134,33 @@ export async function buildWordDocument(
   const hasClassicWorkflows = classicWorkflows.length > 0;
 
   if (hasFlows || hasPlugins || hasClassicWorkflows) {
-    push(blocks, [h(1, 'Automation'), pt('Power Automate flows, classic workflows and plugins in this solution.')], 0);
+    push(content, [h(1, 'Automation'), pt('Power Automate flows, classic workflows and plugins in this solution.')], 0);
 
     if (hasFlows) {
-      push(blocks, renderFlowSummary(flows), 1);
+      push(content, renderFlowSummary(flows), 1);
       for (const flow of flows) {
         const relatedTables = flowDeps.flowToTables.get(flow.id) ?? [];
-        push(blocks, renderSingleFlow(flow, relatedTables), 2);
+        push(content, renderSingleFlow(flow, relatedTables), 2);
       }
     }
 
     if (hasClassicWorkflows) {
-      push(blocks, [h(1, 'Classic Workflows'), ...renderClassicWorkflowsOverview(classicWorkflows)], 1);
+      push(content, [h(1, 'Classic Workflows'), ...renderClassicWorkflowsOverview(classicWorkflows)], 1);
       for (const wf of classicWorkflows) {
-        push(blocks, renderClassicWorkflow(wf), 2);
+        push(content, renderClassicWorkflow(wf), 2);
       }
     }
 
     if (hasPlugins) {
-      push(blocks, renderPluginSummary(validAssemblies), 1);
+      push(content, renderPluginSummary(validAssemblies), 1);
       for (const assembly of validAssemblies) {
-        push(blocks, renderAssemblyIndex(assembly, ''), 2);
+        push(content, renderAssemblyIndex(assembly, ''), 2);
         for (const fullName of assembly.pluginTypeNames) {
           const shortName = fullName.startsWith(assembly.assemblyName + '.')
             ? fullName.slice(assembly.assemblyName.length + 1)
             : fullName;
           const steps = assembly.steps.filter(st => st.className === shortName);
-          push(blocks, renderSinglePluginType(shortName, steps, assembly), 3);
+          push(content, renderSinglePluginType(shortName, steps, assembly), 3);
         }
       }
     }
@@ -171,55 +169,54 @@ export async function buildWordDocument(
   // ---- Custom Code / Web Resources ----
   const jsResources = webResources.filter(r => r.resourceType === 'JavaScript');
   if (jsResources.length > 0) {
-    push(blocks, [h(1, 'Custom Code')], 0);
-    push(blocks, renderWebResourceSummary(jsResources), 1);
+    push(content, [h(1, 'Custom Code')], 0);
+    push(content, renderWebResourceSummary(jsResources), 1);
     for (const resource of jsResources) {
-      push(blocks, renderWebResourceDetail(resource), 2);
+      push(content, renderWebResourceDetail(resource), 2);
     }
   }
 
   // ---- Security Roles ----
   if (securityRoles.length > 0) {
-    push(blocks, renderSecurityRolesIndex(securityRoles, ''), 0);
+    push(content, renderSecurityRolesIndex(securityRoles, ''), 0);
     for (const role of securityRoles) {
-      push(blocks, renderSecurityRolePage(role), 1);
+      push(content, renderSecurityRolePage(role), 1);
     }
   }
 
   // ---- Integrations ----
   if (envVars.length > 0 || connectionRefs.length > 0) {
-    push(blocks, [h(1, 'Integrations')], 0);
-    if (envVars.length > 0)    push(blocks, renderEnvironmentVariablesPage(envVars), 1);
-    if (connectionRefs.length > 0) push(blocks, renderConnectionReferencesPage(connectionRefs), 1);
+    push(content, [h(1, 'Integrations')], 0);
+    if (envVars.length > 0)    push(content, renderEnvironmentVariablesPage(envVars), 1);
+    if (connectionRefs.length > 0) push(content, renderConnectionReferencesPage(connectionRefs), 1);
   }
 
   // ---- Global Choices ----
   if (globalChoices.length > 0) {
-    push(blocks, renderGlobalChoicesIndex(globalChoices, ''), 0);
+    push(content, renderGlobalChoicesIndex(globalChoices, ''), 0);
     for (const choice of globalChoices) {
-      push(blocks, renderGlobalChoicePage(choice), 1);
+      push(content, renderGlobalChoicePage(choice), 1);
     }
   }
 
   // ---- Email Templates ----
   if (emailTemplates.length > 0) {
-    push(blocks, renderEmailTemplatesIndex(emailTemplates, ''), 0);
+    push(content, renderEmailTemplatesIndex(emailTemplates, ''), 0);
     for (const template of emailTemplates) {
-      push(blocks, renderEmailTemplatePage(template), 1);
+      push(content, renderEmailTemplatePage(template), 1);
     }
   }
 
   // ---- Model-Driven Apps ----
   if (modelDrivenApps.length > 0) {
-    push(blocks, renderModelDrivenAppsIndex(modelDrivenApps, ''), 0);
+    push(content, renderModelDrivenAppsIndex(modelDrivenApps, ''), 0);
     for (const app of modelDrivenApps) {
-      push(blocks, renderModelDrivenAppPage(app), 1);
+      push(content, renderModelDrivenAppPage(app), 1);
     }
   }
 
   // ---- Write to disk ----
-  const doc    = buildDocument(blocks);
-  const buffer = await toBuffer(doc);
+  const buffer = await toBuffer(buildDocDefinition(content));
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, buffer);
 }

--- a/src/publisher/wikiAssembler.ts
+++ b/src/publisher/wikiAssembler.ts
@@ -6,6 +6,7 @@ import type {
 } from '../ir/index.js';
 import type { WikiPage } from './wikiPublisher.js';
 import { generateERDiagram } from '../enrichment/erdGenerator.js';
+import { resolveFlowTableDependencies } from '../enrichment/dependencyResolver.js';
 import { serialize } from '../docmodel/MarkdownSerializer.js';
 import { h, toc, mermaid, pt } from '../docmodel/nodes.js';
 import {
@@ -14,6 +15,7 @@ import {
   renderTableForms, renderTableRelationships,
   renderTableBusinessRules, renderSingleBusinessRule,
   renderFlowSummary, renderSingleFlow,
+  renderTableUsedByFlows,
   renderPluginSummary, renderAssemblyIndex, renderSinglePluginType,
   renderWebResourceSummary, renderWebResourceDetail,
   renderClassicWorkflow, renderClassicWorkflowsOverview,
@@ -80,11 +82,15 @@ export function buildWikiPages(
       : serialize([h(1, 'Data Model'), toc()]),
   });
 
+  const flowsBasePath = `${base}/Automation/Flows`;
+  const flowDeps = resolveFlowTableDependencies(flows, mergedSolution.tables);
+
   for (const table of mergedSolution.tables) {
     const tablePath = `${base}/Data Model/${s(table.displayName)}`;
     const tableRules = businessRules.filter(
       r => r.entity.toLowerCase() === table.logicalName.toLowerCase()
     );
+    const tableFlows = flowDeps.tableToFlows.get(table.logicalName.toLowerCase()) ?? [];
 
     pages.push({ path: tablePath,                   content: serialize(renderTableIndex(table)) });
     pages.push({ path: `${tablePath}/Columns`,      content: serialize(renderTableColumns(table)) });
@@ -97,6 +103,9 @@ export function buildWikiPages(
     }
     if (config.components.relationships) {
       pages.push({ path: `${tablePath}/Relationships`, content: serialize(renderTableRelationships(table)) });
+    }
+    if (tableFlows.length > 0) {
+      pages.push({ path: `${tablePath}/Used By Flows`, content: serialize(renderTableUsedByFlows(table, tableFlows, flowsBasePath)) });
     }
 
     const brBasePath = `${tablePath}/Business Rules`;
@@ -119,16 +128,16 @@ export function buildWikiPages(
     });
 
     if (hasFlows) {
-      const flowsBasePath = `${base}/Automation/Flows`;
       pages.push({ path: flowsBasePath, content: serialize(renderFlowSummary(flows, flowsBasePath)) });
       for (const flow of flows) {
-        pages.push({ path: `${flowsBasePath}/${s(flow.name)}`, content: serialize(renderSingleFlow(flow)) });
+        const relatedTables = flowDeps.flowToTables.get(flow.id) ?? [];
+        pages.push({ path: `${flowsBasePath}/${s(flow.name)}`, content: serialize(renderSingleFlow(flow, relatedTables, `${base}/Data Model`)) });
       }
     }
 
     if (hasClassicWorkflows) {
       const cwBasePath = `${base}/Automation/Classic Workflows`;
-      pages.push({ path: cwBasePath, content: serialize(renderClassicWorkflowsOverview(classicWorkflows)) });
+      pages.push({ path: cwBasePath, content: serialize(renderClassicWorkflowsOverview(classicWorkflows, cwBasePath)) });
       for (const wf of classicWorkflows) {
         pages.push({ path: `${cwBasePath}/${s(wf.name)}`, content: serialize(renderClassicWorkflow(wf)) });
       }

--- a/src/renderers/classicWorkflowRenderer.ts
+++ b/src/renderers/classicWorkflowRenderer.ts
@@ -2,7 +2,7 @@
 
 import type { ClassicWorkflowModel, ClassicWorkflowStepModel } from '../ir/classicWorkflow.js';
 import type { DocNode, InlineNode } from '../docmodel/nodes.js';
-import { h, pt, p, t, c, b, i, table, ct, cc, bulletList, bullet } from '../docmodel/nodes.js';
+import { h, pt, p, t, c, b, i, lnk, table, ct, cc, cell, bulletList, bullet } from '../docmodel/nodes.js';
 import { serialize } from '../docmodel/MarkdownSerializer.js';
 import { aiSummaryBlock } from './rendererUtils.js';
 
@@ -143,7 +143,7 @@ export function renderClassicWorkflow(wf: ClassicWorkflowModel): DocNode[] {
 // Overview index table
 // -----------------------------------------------
 
-export function renderClassicWorkflowsOverview(workflows: ClassicWorkflowModel[]): DocNode[] {
+export function renderClassicWorkflowsOverview(workflows: ClassicWorkflowModel[], basePath?: string): DocNode[] {
   if (workflows.length === 0) return [pt('No classic workflows found.')];
 
   return [table(
@@ -161,7 +161,7 @@ export function renderClassicWorkflowsOverview(workflows: ClassicWorkflowModel[]
       if (wf.triggers.onDemand) triggerParts.push('On Demand');
 
       return [
-        ct(wf.name),
+        basePath ? cell(lnk(wf.name, `${basePath}/${wf.name}`)) : ct(wf.name),
         cc(wf.entity),
         ct(wf.category === 'action' ? 'Custom Action' : 'Workflow'),
         ct(wf.mode === 'realtime' ? 'Real-time' : 'Background'),

--- a/src/renderers/flowRenderer.ts
+++ b/src/renderers/flowRenderer.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { FlowModel, FlowActionModel } from '../ir/index.js';
+import type { FlowModel, FlowActionModel, TableModel } from '../ir/index.js';
 import type { DocNode, InlineNode } from '../docmodel/nodes.js';
 import { h, pt, p, t, c, b, i, lnk, table, ct, cc, cell, bulletList, bullet, mermaid } from '../docmodel/nodes.js';
 import { serialize } from '../docmodel/MarkdownSerializer.js';
@@ -66,7 +66,7 @@ function buildActionItems(actions: FlowActionModel[]): ReturnType<typeof bullet>
 // Single flow detail page
 // -----------------------------------------------
 
-export function renderSingleFlow(flow: FlowModel): DocNode[] {
+export function renderSingleFlow(flow: FlowModel, relatedTables?: TableModel[], tablesBasePath?: string): DocNode[] {
   const nodes: DocNode[] = [];
 
   nodes.push(h(1, flow.name));
@@ -103,6 +103,15 @@ export function renderSingleFlow(flow: FlowModel): DocNode[] {
   } else {
     const sorted = sortActionsByOrder(flow.actions);
     nodes.push(bulletList(buildActionItems(sorted)));
+  }
+
+  // ---- Tables Used ----
+  if (relatedTables && relatedTables.length > 0) {
+    nodes.push(h(2, 'Tables Used'));
+    nodes.push(bulletList(relatedTables.map(tbl => bullet(
+      0,
+      tablesBasePath ? lnk(tbl.displayName, `${tablesBasePath}/${tbl.displayName}`) : c(tbl.displayName)
+    ))));
   }
 
   // ---- Diagram ----

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -3,6 +3,7 @@ export {
   renderTableIndex, renderTableColumns, renderTableViews,
   renderTableForms, renderTableRelationships,
   renderTableBusinessRules, renderSingleBusinessRule,
+  renderTableUsedByFlows,
 } from './tableRenderer.js';
 export { renderOverview, writeOverviewMarkdown } from './overviewRenderer.js';
 export { renderFlowMarkdown, renderFlowSummary, renderSingleFlow, writeFlowMarkdown } from './flowRenderer.js';

--- a/src/renderers/tableRenderer.ts
+++ b/src/renderers/tableRenderer.ts
@@ -2,11 +2,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { TableModel, ColumnModel, RelationshipModel } from '../ir/index.js';
+import type { TableModel, ColumnModel, RelationshipModel, FlowModel } from '../ir/index.js';
 import type { DocGenConfig } from '../config/index.js';
 import type { BusinessRuleModel } from '../ir/businessRule.js';
 import type { DocNode, InlineNode } from '../docmodel/nodes.js';
-import { h, pt, p, t, c, b, table, ct, cc, bulletList, bullet, toc } from '../docmodel/nodes.js';
+import { h, pt, p, t, c, b, lnk, table, ct, cc, cell, bulletList, bullet, toc } from '../docmodel/nodes.js';
 import { serialize } from '../docmodel/MarkdownSerializer.js';
 
 // -----------------------------------------------
@@ -217,7 +217,11 @@ export function renderTableRelationships(table_: TableModel): DocNode[] {
   function relRows(relationships: RelationshipModel[]): InlineNode[][][] {
     return relationships.map(rel => {
       const isParent   = rel.referencedEntity.toLowerCase() === table_.logicalName.toLowerCase();
-      const direction  = isParent ? 'One (this) → Many' : 'Many → One (this)';
+      // referencedEntity is always the "one" side (parent); referencingEntity is the
+      // "many" side that holds the lookup. Keep "this" on its correct side of the
+      // arrow in both cases — the previous labels swapped this for the child side,
+      // making it read as if "this" table were always the "one".
+      const direction  = isParent ? 'One (this) → Many' : 'Many (this) → One';
       const otherTable = isParent ? rel.referencingEntity : rel.referencedEntity;
       return [
         ct(rel.name),
@@ -274,6 +278,36 @@ export function renderTableBusinessRules(
   ));
 
   nodes.push(toc());
+
+  return nodes;
+}
+
+// -----------------------------------------------
+// Used By Flows — flows that reference this table
+// -----------------------------------------------
+
+export function renderTableUsedByFlows(
+  table_: TableModel,
+  flows: FlowModel[],
+  basePath?: string
+): DocNode[] {
+  const nodes: DocNode[] = [];
+
+  nodes.push(h(1, `${table_.displayName} — Used By Flows`));
+
+  if (flows.length === 0) {
+    nodes.push(pt('No flows reference this table.'));
+    return nodes;
+  }
+
+  nodes.push(table(
+    ['Flow', 'Trigger Type', 'Status'],
+    flows.map(f => [
+      basePath ? cell(lnk(f.name, `${basePath}/${f.name}`)) : ct(f.name),
+      ct(f.trigger.type),
+      ct(f.isActive ? 'Active' : 'Inactive'),
+    ])
+  ));
 
   return nodes;
 }


### PR DESCRIPTION
## Summary
- New self-contained PDF output format (`output.pdf` config / `--pdf` CLI flag), combinable freely with `--word`/`--wiki`. Built via `PdfSerializer.ts` (DocNode[] → pdfmake content, standard 14 fonts, no bundled font files) and `pdfAssembler.ts` (mirrors `docAssembler.ts` section-by-section).
- Wires the dependency resolver (flow ↔ table cross-links) into both PDF and Word outputs — "Used By Flows" / "Tables Used" sections were present in the wiki but missing from Word/PDF.
- Fixes relationship "Direction" label — child-side cardinality was backwards (e.g. `Many → One (this)` read as if the child were the parent); corrected to `Many (this) → One`.
- Drops orphaned "Diagram" headings in PDF/Word — Mermaid is skipped in both formats but `renderSingleFlow` always emitted the heading regardless.
- Removes forced page breaks before every top-level section heading in both `PdfSerializer` and `DocxSerializer` — was leaving large dead-space gaps whenever a section ended partway down a page (98 → 92 pages on the test solution); sections now flow naturally, Word gets `keepNext` as an orphan-heading safeguard.
- Syncs `docs/architecture.jsx` (PDF renderer marked built, phase groupings/names/status synced to the GitHub Roadmap project board, version bumped to match `package.json`).

New dependency: `pdfmake` (+ `@types/pdfmake`) — chosen for self-contained PDF output with no font files or native binaries to ship.

closes #67

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] Regenerated PDF + Word docs locally (`npx tsx src/index.ts --pdf --word`) against test solution
- [x] Verified "Used By Flows"/"Tables Used" sections render correctly in both PDF and Word
- [x] Verified zero orphaned "Diagram" headings remain in either format
- [x] Verified relationship Direction labels read correctly for both parent/child sides in Word (python-docx) — PDF shares the same renderer
- [x] Verified PDF page count dropped 98 → 92 with no dead-space regressions, spot-checked rendered pages
- [x] Lewis to review rendered PDF/Word output and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)