### PR TITLE
fix: trigger npm publish on release published, not created

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,10 @@ on:
     # published later via the UI (the latter only fires `published`, not
     # `created` — this is what caused v1.4.0 to silently skip npm publish).
     types: [created, published]
+  # Manual escape hatch — lets us (re)trigger an npm publish from the Actions
+  # tab or `gh workflow run "Publish to npm"` without needing a release event
+  # at all (e.g. if a release event is ever missed again, or to republish).
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,13 @@ name: Publish to npm
 
 on:
   release:
-    types: [created]
+    # `created` fires when a release object is first created — including
+    # drafts. `published` fires when a release becomes publicly available,
+    # which is what actually matters for triggering an npm publish — this
+    # covers both releases created directly as published *and* drafts
+    # published later via the UI (the latter only fires `published`, not
+    # `created` — this is what caused v1.4.0 to silently skip npm publish).
+    types: [created, published]
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- The npm-publish workflow only listened for the `release: created` event, but publishing a draft release (the workflow we use for v1.4.0+) fires a `published` event instead — so the workflow silently never ran and v1.4.0 was never pushed to npm.
- Adds `published` to the trigger's event types alongside `created`, covering both directly-published releases and draft → published transitions.

## Test plan
- [ ] Merge this fix
- [ ] Re-trigger the v1.4.0 publish (toggle the release draft state off/on, or re-run via Actions once the new trigger is live) and confirm the "Publish to npm" workflow runs and `npm publish` succeeds
- [ ] Confirm `powerautodocs@1.4.0` appears on npmjs.com